### PR TITLE
chore: update Terraform required version constraint

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -5,5 +5,5 @@ terraform {
       version = "~> 5.0"
     }
   }
-  required_version = ">= 1.1.9"
+  required_version = ">= 1.3"
 }


### PR DESCRIPTION
Updates the required Terraform version from 1.1.9 to 1.3 to ensure
compatibility with new features and improvements introduced in
the latest version. This change supports better project stability
and reduces potential issues during deployment.